### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -18,7 +18,7 @@ jobs:
             sudo rm -rf /opt/ghc
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: mlf-core/liver_ct_segmentation
         username: mlf-core


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore